### PR TITLE
building with msys2

### DIFF
--- a/include/itslib/util/wintypes.h
+++ b/include/itslib/util/wintypes.h
@@ -10,7 +10,7 @@
 #include <errno.h>
 inline uint32_t GetLastError() { return errno; }
 #endif
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <windows.h>
 #include <tchar.h>
 #elif defined(USING_SYNCE)

--- a/src/stringutils.cpp
+++ b/src/stringutils.cpp
@@ -27,7 +27,7 @@ int strcasecmp(const char *, const char *);
 #ifdef __GNUC__
 #include <errno.h>
 #endif
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__MINGW32__)
 
 // MSVC: the buffer is assumed to contain a 0 at buf[size]
 // NOTE: with gcc, you'd have to specify str.size()+1


### PR DESCRIPTION
MSVC is not the only compiler on windows.

ext2rd will compile then flawlessly as well.
![image](https://github.com/nlitsme/legacy-itslib-library/assets/2415206/320b26cc-2463-42e2-b065-d7c4f764a6b1)
